### PR TITLE
 Take into account already executed, but skipped modules when determining the "last" module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,30 +175,12 @@
                             <postBuildHookScript>verify</postBuildHookScript>
                             <streamLogs>true</streamLogs>
                             <pomIncludes>
-                                <pomInclude>configuration/storelifecycleconversion/pom.xml</pomInclude>
-                                <pomInclude>singlemodule/storeconfiguration/pom.xml</pomInclude>
-                                <pomInclude>singlemodule/site/pom.xml</pomInclude>
-                                <pomInclude>singlemodule/junit-report/pom.xml</pomInclude>
-                                <pomInclude>singlemodule/export-rules/pom.xml</pomInclude>
-                                <pomInclude>singlemodule/skip/pom.xml</pomInclude>
-                                <pomInclud>singlemodule/scanincludes/pom.xml</pomInclud>
-                                <pomInclude>singlemodule/severity/pom.xml</pomInclude>
-                                <pomInclude>singlemodule/defaultseverity/pom.xml</pomInclude>
-                                <pomInclude>singlemodule/shade/pom.xml</pomInclude>
-                                <pomInclude>singlemodule/model/pom.xml</pomInclude>
-                                <pomInclude>singlemodule/ruleparameter/pom.xml</pomInclude>
-                                <pomInclude>multimodule/singleparent/site/pom.xml</pomInclude>
-                                <pomInclude>multimodule/singleparent/skip/pom.xml</pomInclude>
-                                <pomInclude>multimodule/singleparent/customruledir/pom.xml</pomInclude>
-                                <pomInclude>multimodule/singleparent/multipleruledirs/pom.xml</pomInclude>
-                                <pomInclude>multimodule/singleparent/parentasmodule/pom.xml</pomInclude>
-                                <pomInclude>multimodule/singleparent/execrootasprojectroot/pom.xml</pomInclude>
-                                <pomInclude>multimodule/singleparent/cliwithoutplugin/pom.xml</pomInclude>
-                                <pomInclude>multimodule/singleparent/dependency/pom.xml</pomInclude>
-                                <pomInclude>multimodule/multiparent/site/pom.xml</pomInclude>
-                                <pomInclude>multimodule/multiparent/singlestore/pom.xml</pomInclude>
-                                <pomInclude>tycho/additionalfiles/pom.xml</pomInclude>
-                                <pomInclude>plugin/pom.xml</pomInclude>
+                                <!-- Use -Dinvoker.test=<pattern> to override the configuration below on the commandline -->
+                                <include>configuration/*/pom.xml</include>
+                                <include>singlemodule/*/pom.xml</include>
+                                <include>multimodule/*/*/pom.xml</include>
+                                <include>tycho/*/pom.xml</include>
+                                <include>plugin/pom.xml</include>
                             </pomIncludes>
                         </configuration>
                         <executions>

--- a/src/it/multimodule/singleparent/analyze-lastmodule/invoker.properties
+++ b/src/it/multimodule/singleparent/analyze-lastmodule/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals.1 = install
+invoker.buildResult.1 = failure

--- a/src/it/multimodule/singleparent/analyze-lastmodule/jqassistant/default.xml
+++ b/src/it/multimodule/singleparent/analyze-lastmodule/jqassistant/default.xml
@@ -5,7 +5,7 @@
     </group>
 
     <constraint id="a" severity="major">
-        <description>A constraint with severity major.</description>
+        <description>A constraint that always fails.</description>
         <cypher>
             RETURN 1
         </cypher>

--- a/src/it/multimodule/singleparent/analyze-lastmodule/module1/pom.xml
+++ b/src/it/multimodule/singleparent/analyze-lastmodule/module1/pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>@project.groupId@</groupId>
+		<artifactId>@project.artifactId@.integration.multimodule.singleparent.analyze-lastmodule</artifactId>
+		<version>@project.version@</version>
+	</parent>
+	<artifactId>@project.artifactId@.integration.multimodule.singleparent.analyze-lastmodule.module1</artifactId>
+
+	<properties>
+		<jqassistant.skip>true</jqassistant.skip>
+	</properties>
+</project>

--- a/src/it/multimodule/singleparent/analyze-lastmodule/module2/pom.xml
+++ b/src/it/multimodule/singleparent/analyze-lastmodule/module2/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>@project.groupId@</groupId>
+		<artifactId>@project.artifactId@.integration.multimodule.singleparent.analyze-lastmodule</artifactId>
+		<version>@project.version@</version>
+	</parent>
+	<artifactId>@project.artifactId@.integration.multimodule.singleparent.analyze-lastmodule.module2</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/it/multimodule/singleparent/analyze-lastmodule/module3/pom.xml
+++ b/src/it/multimodule/singleparent/analyze-lastmodule/module3/pom.xml
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>@project.groupId@</groupId>
+		<artifactId>@project.artifactId@.integration.multimodule.singleparent.analyze-lastmodule</artifactId>
+		<version>@project.version@</version>
+	</parent>
+	<artifactId>@project.artifactId@.integration.multimodule.singleparent.analyze-lastmodule.module3</artifactId>
+</project>

--- a/src/it/multimodule/singleparent/analyze-lastmodule/module4/pom.xml
+++ b/src/it/multimodule/singleparent/analyze-lastmodule/module4/pom.xml
@@ -1,0 +1,10 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>@project.groupId@</groupId>
+		<artifactId>@project.artifactId@.integration.multimodule.singleparent.analyze-lastmodule</artifactId>
+		<version>@project.version@</version>
+	</parent>
+	<artifactId>@project.artifactId@.integration.multimodule.singleparent.analyze-lastmodule.module4</artifactId>
+</project>

--- a/src/it/multimodule/singleparent/analyze-lastmodule/pom.xml
+++ b/src/it/multimodule/singleparent/analyze-lastmodule/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>@project.groupId@</groupId>
+		<artifactId>@project.artifactId@.integration</artifactId>
+		<version>@project.version@</version>
+		<relativePath>../../../pom.xml</relativePath>
+	</parent>
+	<artifactId>@project.artifactId@.integration.multimodule.singleparent.analyze-lastmodule</artifactId>
+	<packaging>pom</packaging>
+
+	<modules>
+		<module>module1</module>
+		<module>module2</module>
+        <module>module3</module>
+        <module>module4</module>
+	</modules>
+</project>

--- a/src/it/multimodule/singleparent/analyze-lastmodule/verify.groovy
+++ b/src/it/multimodule/singleparent/analyze-lastmodule/verify.groovy
@@ -1,0 +1,27 @@
+def reportFile = new File(basedir, 'build.log')
+boolean foundModule1Violation = false
+boolean foundModule2Violation = false
+boolean foundModule3Violation = false
+boolean foundModule4Violation = false
+reportFile.eachLine {
+    if (!foundModule1Violation) {
+        foundModule1Violation = isViolationLogLineForModule('module1', it)
+    }
+    if (!foundModule2Violation) {
+        foundModule2Violation = isViolationLogLineForModule('module2', it)
+    }
+    if (!foundModule3Violation) {
+        foundModule3Violation = isViolationLogLineForModule('module3', it)
+    }
+    if (!foundModule4Violation) {
+        foundModule4Violation = isViolationLogLineForModule('module4', it)
+    }
+}
+assert !foundModule1Violation // Skipped - should not analyze yet
+assert !foundModule2Violation // Skipped - should not analyze yet
+assert !foundModule3Violation // Not the last module - should not analyze yet
+assert foundModule4Violation // Should finally analyze and find the violation
+
+static boolean isViolationLogLineForModule(String moduleName, String line) {
+    line ==~ /^\[ERROR\] Failed to execute goal com.buschmais.jqassistant:jqassistant-maven-plugin:.* on project jqassistant-maven-plugin.integration.multimodule.singleparent.analyze-lastmodule.$moduleName: Violations detected.*$/
+}


### PR DESCRIPTION
This is important when executing the "analyze" goal in particular: if we ignore skipped modules, and the project skips the jqassistant plugin in the very first module for example,  we will never consider that we are executing the last module, and thus we will never execute the "analyze" goal.

We manage to take skipped modules into account by using a simpler approach to determine whether the current module is the last one.

See the first commit for a (initially failing) test proving this patch actually solves a real problem.

This also includes a fix for the maven-invoker-plugin configuration, because some tests were being ignored.